### PR TITLE
Bump up go version 1.20.5 to 1.20.6.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/bearfield/debian-fish:bookworm
 #
 # set env
-ENV GOLANG_VERSION=1.20.5
+ENV GOLANG_VERSION=1.20.6
 ENV PATH /usr/local/go/bin:$PATH
 
 #


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

- Chore: DockerfileのGoバージョンを1.20.5から1.20.6に更新しました。

> おめでとう！DockerfileのGoバージョンがアップデートされました。新しいバージョンでより安定性とパフォーマンスが向上することを願っています。頑張ってください！🎉
<!-- end of auto-generated comment: release notes by openai -->